### PR TITLE
[breaking] Include /v1/ in the sync-server paths

### DIFF
--- a/docs/src/sync-protocol.md
+++ b/docs/src/sync-protocol.md
@@ -73,7 +73,7 @@ This value is passed with every request in the `X-Client-Id` header, in its dash
 
 ### AddVersion
 
-The request is a `POST` to `<origin>/client/add-version/<parentVersionId>`.
+The request is a `POST` to `<origin>/v1/client/add-version/<parentVersionId>`.
 The request body contains the history segment, optionally encoded using any encoding supported by actix-web.
 The content-type must be `application/vnd.taskchampion.history-segment`.
 
@@ -87,7 +87,7 @@ Other error responses (4xx or 5xx) may be returned and should be treated appropr
 
 ### GetChildVersion
 
-The request is a `GET` to `<origin>/client/get-child-version/<parentVersionId>`.
+The request is a `GET` to `<origin>/v1/client/get-child-version/<parentVersionId>`.
 The response is 404 NOT FOUND if no such version exists.
 Otherwise, the response is a 200 OK.
 The version's history segment is returned in the response body, with content-type `application/vnd.taskchampion.history-segment`.

--- a/sync-server/src/api/add_version.rs
+++ b/sync-server/src/api/add_version.rs
@@ -19,7 +19,7 @@ const MAX_SIZE: usize = 100 * 1024 * 1024;
 /// parent version ID in the `X-Parent-Version-Id` header.
 ///
 /// Returns other 4xx or 5xx responses on other errors.
-#[post("/client/add-version/{parent_version_id}")]
+#[post("/v1/client/add-version/{parent_version_id}")]
 pub(crate) async fn service(
     req: HttpRequest,
     server_state: web::Data<ServerState>,
@@ -99,7 +99,7 @@ mod test {
         let server_state = ServerState::new(server_box);
         let mut app = test::init_service(App::new().service(app_scope(server_state))).await;
 
-        let uri = format!("/client/add-version/{}", parent_version_id);
+        let uri = format!("/v1/client/add-version/{}", parent_version_id);
         let req = test::TestRequest::post()
             .uri(&uri)
             .header(
@@ -136,7 +136,7 @@ mod test {
         let server_state = ServerState::new(server_box);
         let mut app = test::init_service(App::new().service(app_scope(server_state))).await;
 
-        let uri = format!("/client/add-version/{}", parent_version_id);
+        let uri = format!("/v1/client/add-version/{}", parent_version_id);
         let req = test::TestRequest::post()
             .uri(&uri)
             .header(
@@ -163,7 +163,7 @@ mod test {
         let server_state = ServerState::new(server_box);
         let mut app = test::init_service(App::new().service(app_scope(server_state))).await;
 
-        let uri = format!("/client/add-version/{}", parent_version_id);
+        let uri = format!("/v1/client/add-version/{}", parent_version_id);
         let req = test::TestRequest::post()
             .uri(&uri)
             .header("Content-Type", "not/correct")
@@ -182,7 +182,7 @@ mod test {
         let server_state = ServerState::new(server_box);
         let mut app = test::init_service(App::new().service(app_scope(server_state))).await;
 
-        let uri = format!("/client/add-version/{}", parent_version_id);
+        let uri = format!("/v1/client/add-version/{}", parent_version_id);
         let req = test::TestRequest::post()
             .uri(&uri)
             .header(

--- a/sync-server/src/api/get_child_version.rs
+++ b/sync-server/src/api/get_child_version.rs
@@ -13,7 +13,7 @@ use actix_web::{error, get, web, HttpRequest, HttpResponse, Result};
 ///
 /// If no such child exists, returns a 404 with no content.
 /// Returns other 4xx or 5xx responses on other errors.
-#[get("/client/get-child-version/{parent_version_id}")]
+#[get("/v1/client/get-child-version/{parent_version_id}")]
 pub(crate) async fn service(
     req: HttpRequest,
     server_state: web::Data<ServerState>,
@@ -68,7 +68,7 @@ mod test {
         let server_state = ServerState::new(server_box);
         let mut app = test::init_service(App::new().service(app_scope(server_state))).await;
 
-        let uri = format!("/client/get-child-version/{}", parent_version_id);
+        let uri = format!("/v1/client/get-child-version/{}", parent_version_id);
         let req = test::TestRequest::get()
             .uri(&uri)
             .header("X-Client-Key", client_key.to_string())
@@ -101,7 +101,7 @@ mod test {
         let server_state = ServerState::new(server_box);
         let mut app = test::init_service(App::new().service(app_scope(server_state))).await;
 
-        let uri = format!("/client/get-child-version/{}", parent_version_id);
+        let uri = format!("/v1/client/get-child-version/{}", parent_version_id);
         let req = test::TestRequest::get()
             .uri(&uri)
             .header("X-Client-Key", client_key.to_string())
@@ -126,7 +126,7 @@ mod test {
         let server_state = ServerState::new(server_box);
         let mut app = test::init_service(App::new().service(app_scope(server_state))).await;
 
-        let uri = format!("/client/get-child-version/{}", parent_version_id);
+        let uri = format!("/v1/client/get-child-version/{}", parent_version_id);
         let req = test::TestRequest::get()
             .uri(&uri)
             .header("X-Client-Key", client_key.to_string())

--- a/taskchampion/src/server/remote/mod.rs
+++ b/taskchampion/src/server/remote/mod.rs
@@ -49,7 +49,10 @@ impl Server for RemoteServer {
         parent_version_id: VersionId,
         history_segment: HistorySegment,
     ) -> anyhow::Result<AddVersionResult> {
-        let url = format!("{}/client/add-version/{}", self.origin, parent_version_id);
+        let url = format!(
+            "{}/v1/client/add-version/{}",
+            self.origin, parent_version_id
+        );
         let history_cleartext = HistoryCleartext {
             parent_version_id,
             history_segment,
@@ -82,7 +85,7 @@ impl Server for RemoteServer {
         parent_version_id: VersionId,
     ) -> anyhow::Result<GetVersionResult> {
         let url = format!(
-            "{}/client/get-child-version/{}",
+            "{}/v1/client/get-child-version/{}",
             self.origin, parent_version_id
         );
         match self


### PR DESCRIPTION
This is an incompatible change to the sync-server protocol.

Fixes #151.