### PR TITLE
Include git HEAD rev in version output

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -4,6 +4,8 @@ edition = "2018"
 name = "taskchampion-cli"
 version = "0.3.0"
 
+build = "build.rs"
+
 [dependencies]
 dirs-next = "^2.0.0"
 env_logger = "^0.8.3"

--- a/cli/build.rs
+++ b/cli/build.rs
@@ -1,0 +1,34 @@
+use std::process::Command;
+
+fn main() {
+    // Query HEAD revision and expose as $TC_GIT_REV during build
+    //
+    // Adapted from https://stackoverflow.com/questions/43753491
+    let cmd = Command::new("git")
+        .args(&["rev-parse", "--short", "HEAD"])
+        .spawn()
+        // Wait for process to exit
+        .and_then(|cmd| cmd.wait_with_output())
+        // Handle error if failed to launch git
+        .map_err(|_e| println!("cargo:warning=Failed to run 'git' to determine HEAD rev"))
+        // Remap to Some/None for simpler error handling
+        .ok()
+        // Handle command failing
+        .and_then(|o| {
+            if o.status.success() {
+                Some(o)
+            } else {
+                println!(
+                    "cargo:warning='git' exited with non-zero exit code while determining HEAD rev"
+                );
+                None
+            }
+        })
+        // Get output as UTF-8 string
+        .map(|out| String::from_utf8(out.stdout).expect("Invalid output in stdout"));
+
+    // Only output git rev if successful
+    if let Some(h) = cmd {
+        println!("cargo:rustc-env=TC_GIT_REV={}", h);
+    }
+}

--- a/cli/src/invocation/cmd/version.rs
+++ b/cli/src/invocation/cmd/version.rs
@@ -3,8 +3,13 @@ use termcolor::{ColorSpec, WriteColor};
 pub(crate) fn execute<W: WriteColor>(w: &mut W) -> anyhow::Result<()> {
     write!(w, "TaskChampion ")?;
     w.set_color(ColorSpec::new().set_bold(true))?;
-    writeln!(w, "{}", env!("CARGO_PKG_VERSION"))?;
+    write!(w, "{}", env!("CARGO_PKG_VERSION"))?;
     w.reset()?;
+
+    if let Some(h) = option_env!("TC_GIT_REV") {
+        write!(w, " (git rev: {})", h)?;
+    }
+    writeln!(w)?;
     Ok(())
 }
 


### PR DESCRIPTION
As per #241

Output is something like:

```
TaskChampion 0.3.0 (git rev: 1d6c3aa)
```
