### PR TITLE
Make 'cargo run' run ta binary

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -6,6 +6,9 @@ version = "0.3.0"
 
 build = "build.rs"
 
+# Run 'ta' when doing 'cargo run' at repo root
+default-run = "ta"
+
 [dependencies]
 dirs-next = "^2.0.0"
 env_logger = "^0.8.3"


### PR DESCRIPTION
Seems kind of handy:

```
$ cd taskchampion
$ cargo run
```
Previously this would have errored with
```
error: `cargo run` could not determine which binary to run. Use the `--bin` option to specify a binary, or the `default-run` manifest key.
```

Everything else should still function as before, e.g:
```
$ cargo run --bin ta
$ cargo run --bin taskchampion-sync-server
$ cd sync-server
$ cargo run # runs sync-server
```