### PR TITLE
Use `built` to determine version information

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -536,6 +536,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "built"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f346b6890a0dfa7266974910e7df2d5088120dd54721b9b0e5aae1ae5e05715"
+dependencies = [
+ "cargo-lock",
+ "git2",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -575,10 +585,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "cargo-lock"
+version = "7.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a19807e9f4f8af2c8ece4236ed7d229b9179da1f3f2ba44e765c7ba934748f99"
+dependencies = [
+ "semver 1.0.3",
+ "serde",
+ "toml",
+ "url",
+]
+
+[[package]]
 name = "cc"
 version = "1.0.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3c69b077ad434294d3ce9f1f6143a2a4b89a8a2d54ef813d85003a4fd1137fd"
+dependencies = [
+ "jobserver",
+]
 
 [[package]]
 name = "cfg-if"
@@ -1141,6 +1166,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "git2"
+version = "0.13.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9831e983241f8c5591ed53f17d874833e2fa82cac2625f3888c50cbfe136cba"
+dependencies = [
+ "bitflags",
+ "libc",
+ "libgit2-sys",
+ "log",
+ "url",
+]
+
+[[package]]
 name = "gitignore"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1431,6 +1469,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd25036021b0de88a0aff6b850051563c6516d0bf53f8638938edbb9de732736"
 
 [[package]]
+name = "jobserver"
+version = "0.1.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "972f5ae5d1cb9c6ae417789196c803205313edde988685da5e3aae0827b9e7fd"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "js-sys"
 version = "0.3.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1498,6 +1545,30 @@ name = "libc"
 version = "0.2.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9385f66bf6105b241aa65a61cb923ef20efc665cb9f9bb50ac2f0c4b7f378d41"
+
+[[package]]
+name = "libgit2-sys"
+version = "0.12.21+1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86271bacd72b2b9e854c3dcfb82efd538f15f870e4c11af66900effb462f6825"
+dependencies = [
+ "cc",
+ "libc",
+ "libz-sys",
+ "pkg-config",
+]
+
+[[package]]
+name = "libz-sys"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de5435b8549c16d423ed0c03dbaafe57cf6c3344744f1242520d59c9d8ecec66"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
 
 [[package]]
 name = "linked-hash-map"
@@ -2557,6 +2628,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "semver"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f3aac57ee7f3272d8395c6e4f502f434f0e289fcd62876f70daa008c20dcabe"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "semver-parser"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2869,6 +2949,7 @@ dependencies = [
  "anyhow",
  "assert_cmd",
  "atty",
+ "built",
  "chrono",
  "dirs-next",
  "env_logger 0.8.3",
@@ -3410,6 +3491,12 @@ dependencies = [
  "getrandom 0.2.2",
  "serde",
 ]
+
+[[package]]
+name = "vcpkg"
+version = "0.2.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "025ce40a007e1907e58d5bc1a594def78e5573bb0b1160bc389634e8f12e4faa"
 
 [[package]]
 name = "vec_map"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -33,6 +33,9 @@ serde_json = { version = "*", optional = true }
 [dependencies.taskchampion]
 path = "../taskchampion"
 
+[build-dependencies]
+built = { version = "0.5", features = ["git2"] }
+
 [dev-dependencies]
 assert_cmd = "^1.0.3"
 predicates = "^1.0.7"

--- a/cli/build.rs
+++ b/cli/build.rs
@@ -1,34 +1,3 @@
-use std::process::Command;
-
 fn main() {
-    // Query HEAD revision and expose as $TC_GIT_REV during build
-    //
-    // Adapted from https://stackoverflow.com/questions/43753491
-    let cmd = Command::new("git")
-        .args(&["rev-parse", "--short", "HEAD"])
-        .spawn()
-        // Wait for process to exit
-        .and_then(|cmd| cmd.wait_with_output())
-        // Handle error if failed to launch git
-        .map_err(|_e| println!("cargo:warning=Failed to run 'git' to determine HEAD rev"))
-        // Remap to Some/None for simpler error handling
-        .ok()
-        // Handle command failing
-        .and_then(|o| {
-            if o.status.success() {
-                Some(o)
-            } else {
-                println!(
-                    "cargo:warning='git' exited with non-zero exit code while determining HEAD rev"
-                );
-                None
-            }
-        })
-        // Get output as UTF-8 string
-        .map(|out| String::from_utf8(out.stdout).expect("Invalid output in stdout"));
-
-    // Only output git rev if successful
-    if let Some(h) = cmd {
-        println!("cargo:rustc-env=TC_GIT_REV={}", h);
-    }
+    built::write_built_file().expect("Failed to acquire build-time information");
 }

--- a/cli/src/invocation/cmd/version.rs
+++ b/cli/src/invocation/cmd/version.rs
@@ -1,13 +1,18 @@
+use crate::built_info;
 use termcolor::{ColorSpec, WriteColor};
 
 pub(crate) fn execute<W: WriteColor>(w: &mut W) -> Result<(), crate::Error> {
     write!(w, "TaskChampion ")?;
     w.set_color(ColorSpec::new().set_bold(true))?;
-    write!(w, "{}", env!("CARGO_PKG_VERSION"))?;
+    write!(w, "{}", built_info::PKG_VERSION)?;
     w.reset()?;
 
-    if let Some(h) = option_env!("TC_GIT_REV") {
-        write!(w, " (git rev: {})", h)?;
+    if let (Some(version), Some(dirty)) = (built_info::GIT_VERSION, built_info::GIT_DIRTY) {
+        if dirty {
+            write!(w, " (git version: {} with un-committed changes)", version)?;
+        } else {
+            write!(w, " (git version: {})", version)?;
+        };
     }
     writeln!(w)?;
     Ok(())

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -44,6 +44,11 @@ mod settings;
 mod table;
 mod usage;
 
+/// See https://docs.rs/built
+pub(crate) mod built_info {
+    include!(concat!(env!("OUT_DIR"), "/built.rs"));
+}
+
 pub(crate) use errors::Error;
 use settings::Settings;
 


### PR DESCRIPTION
The existing invocation of `git` wasn't working for me:
```
cleave ~/p/taskchampion [use-built] $ ta version                                                                                                                                                                                                                                                  
TaskChampion 0.3.0 (git rev: )                                                                                                                   
```

this PR does about the same thing, but outsourcing the version determination to Someone Else's Crate.