### PR TITLE
Changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,20 @@
+# Changelog
+
+## [Unreleased]
+
+Note: unreleased change log entries are kept in `.changelogs/` directory in repo root, and can be added with `./script/changelog.py add "Added thing for reason"
+
+## 0.3.0 - 2021-01-11
+- Flexible named reports
+- Updates to the TaskChampion crate API
+- Usability improvements
+
+## 0.2.0 - 2020-11-30
+
+This release is the first "MVP" version of this tool. It can do basic task operations, and supports a synchronization. Major missing features are captured in issues, but briefly:
+
+    better command-line API, similar to TaskWarrior
+    authentication of the replica / server protocol
+    encryption of replica data before transmission to the server
+    lots of task features (tags, annotations, dependencies, ..)
+    lots of CLI features (filtering, modifying, ..)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,6 +7,10 @@ It also means that things are changing quickly, and lots of stuff is planned tha
 If you would like to work on TaskChampion, please contact the developers (via the issue tracker) before spending a lot of time working on a pull request.
 Doing so may save you some wasted time and frustration!
 
+A good starting point might be one of the issues tagged with ["good first issue"][first].
+
+[first]: https://github.com/taskchampion/taskchampion/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22
+
 # Other Ways To Help
 
 The best way to help this project to grow is to help spread awareness of it.
@@ -15,7 +19,6 @@ Tell your friends, post to social media, blog about it -- whatever works best!
 Other ideas;
  * Improve the documentation where it's unclear or lacking some information
  * Build and maintain tools that integrate with TaskChampion
- * Devise a nice TaskChampion logo
 
 # Development Guide
 
@@ -44,8 +47,19 @@ You may be able to limit the scope of what you need to understand to just one cr
  
  You can generate the documentation for the `taskchampion` crate with `cargo doc --release --open -p taskchampion`.
  
- ## Making a Pull Request
+## Making a Pull Request
  
- We expect contributors to follow the [GitHub Flow](https://guides.github.com/introduction/flow/).
- Aside from that, we have no particular requirements on pull requests.
- Make your patch, double-check that it's complete (tests? docs? documentation comments?), and make a new pull request.
+We expect contributors to follow the [GitHub Flow](https://guides.github.com/introduction/flow/).
+Aside from that, we have no particular requirements on pull requests.
+Make your patch, double-check that it's complete (tests? docs? documentation comments?), and make a new pull request.
+
+Any non-trivial change (particularly those that change the behaviour of the application, or change the API) should be noted in the projects changelog.
+In order to manage this, changelog entries are stored as text files in the `.changelog/` directory at the repository root.
+
+To add a new changelog entry, you can simply run `python3 ./script/changelog.py add "Fixed thingo to increase zorbloxification [Issue #2](http://example.com)`
+
+This creates a file named `./changelogs/yyyy-mm-dd-branchname.txt` (timestamp, current git branch) which contains a markdown snippet.
+
+If you don't have a Python 3 intepreter installed, you can simply create this file manually. It should contain a list item like `- Fixed thingo [...]`
+
+Periodically (probably just before release), these changelog entries are concatenated combined together and added into the `CHANGELOG.md` file.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -58,7 +58,7 @@ In order to manage this, changelog entries are stored as text files in the `.cha
 
 To add a new changelog entry, you can simply run `python3 ./script/changelog.py add "Fixed thingo to increase zorbloxification [Issue #2](http://example.com)`
 
-This creates a file named `./changelogs/yyyy-mm-dd-branchname.txt` (timestamp, current git branch) which contains a markdown snippet.
+This creates a file named `./changelogs/yyyy-mm-dd-branchname.md` (timestamp, current git branch) which contains a markdown snippet.
 
 If you don't have a Python 3 intepreter installed, you can simply create this file manually. It should contain a list item like `- Fixed thingo [...]`
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,5 +1,6 @@
 # Release process
 
+1. Ensure the changelog is updated with everything from the `.changelogs` directory. `python3 ./script/changelog.py build` will output a Markdown snippet to include in `CHANGELOG.md` then `rm .changelog/*.txt`
 1. Run `git pull upstream main`
 1. Run `cargo test`
 1. Run `cargo clean && cargo clippy`

--- a/scripts/changelog.py
+++ b/scripts/changelog.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3
+import os
+import argparse
+import datetime
+import subprocess
+from typing import List
+
+def ymd():
+    return datetime.datetime.now().strftime("%Y-%m-%d")
+
+def git_current_branch() -> str :
+    out = subprocess.check_output(["git", "branch", "--show-current"])
+    return out.strip().decode("utf-8")
+
+def get_dir() -> str:
+    here = os.path.dirname(os.path.abspath(__file__))
+    return os.path.join(
+        here,
+        "../.changelogs")
+
+def get_changefiles() -> List[str]:
+    changedir = get_dir()
+    changefiles = []
+    for f in os.listdir(changedir):
+        if f.endswith(".txt") and not f.startswith("."):
+            changefiles.append(os.path.join(changedir, f))
+
+    return changefiles
+
+def cmd_add(args):
+    text = args.text.strip()
+    if not text.startswith("- "):
+        text = "- %s" % text
+
+    timestamp = ymd()
+    branchname = git_current_branch()
+    fname = os.path.join(get_dir(), "%s-%s.txt" % (timestamp, branchname))
+    with open(fname, "a") as f:
+        f.write(text)
+        f.write("\n")
+
+def cmd_build(args):
+    print("## x.y.z - %s" % (ymd()))
+    for e in get_changefiles():
+        print(open(e).read().strip())
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    subparsers = parser.add_subparsers(title='Sub commands', dest='command')
+    subparsers.required = True
+
+    parser_add = subparsers.add_parser('add')
+    parser_add.add_argument("text")
+    parser_add.set_defaults(func=cmd_add)
+
+    parser_build = subparsers.add_parser('build')
+    parser_build.set_defaults(func=cmd_build)
+
+    args = parser.parse_args()
+    args.func(args)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/changelog.py
+++ b/scripts/changelog.py
@@ -22,7 +22,7 @@ def get_changefiles() -> List[str]:
     changedir = get_dir()
     changefiles = []
     for f in os.listdir(changedir):
-        if f.endswith(".txt") and not f.startswith("."):
+        if f.endswith(".md") and not f.startswith("."):
             changefiles.append(os.path.join(changedir, f))
 
     return changefiles
@@ -34,7 +34,7 @@ def cmd_add(args):
 
     timestamp = ymd()
     branchname = git_current_branch()
-    fname = os.path.join(get_dir(), "%s-%s.txt" % (timestamp, branchname))
+    fname = os.path.join(get_dir(), "%s-%s.md" % (timestamp, branchname))
     with open(fname, "a") as f:
         f.write(text)
         f.write("\n")


### PR DESCRIPTION
I figured we should probably have a `CHANGELOG` file of some kind - the releases section is fine, but:
1. It's nice having it recorded in the main repo also, not just on Github
2. It's good to have the original author write the changelog entry at the time of PR (even if they get edited or rewritten at release time)
3. Should make it easier at release time than retroactively describing all the changes based on `git log`

Also to avoid having every concurrent PR ending up with minor merge-conflict on the CHANGELOG.md file, I shoved together a simple version of [something like this](https://about.gitlab.com/blog/2018/07/03/solving-gitlabs-changelog-conflict-crisis/)

> Also simple process/script to manage entries in PR's without merge conflicts:
> 
> 1. Unreleased entries area stored as text files in ".changelogs/"
> 2. On release these are concatenated together and put in CHANGELOG.md
> 
> Script basically just add line of text to a "YYYY-MM-DD-branch.txt" formatted file

For example:
```
$ ./scripts/changelog.py add "Improved thing for reason"
$ ls .changelogs/
2021-06-20-changelog.txt
$ cat .changelogs/2021-06-20-changelog.txt
- Improved thing for reason
$ ./scripts/changelog.py build
## x.y.z - 2021-06-20
- Improved thing for reason
```

(it doesn't really *need* a script, a simple `echo ... > .changelogs/1999-01-01.txt` would work fine, it's mostly just to save me having to remember the current date 🙄)