### PR TITLE
Replace NO_VERSION_ID with NIL_VERSION_ID

### DIFF
--- a/sync-server/src/api/add_snapshot.rs
+++ b/sync-server/src/api/add_snapshot.rs
@@ -1,5 +1,5 @@
 use crate::api::{client_key_header, failure_to_ise, ServerState, SNAPSHOT_CONTENT_TYPE};
-use crate::server::{add_snapshot, VersionId, NO_VERSION_ID};
+use crate::server::{add_snapshot, VersionId, NIL_VERSION_ID};
 use actix_web::{error, post, web, HttpMessage, HttpRequest, HttpResponse, Result};
 use futures::StreamExt;
 
@@ -52,7 +52,7 @@ pub(crate) async fn service(
     let client = match txn.get_client(client_key).map_err(failure_to_ise)? {
         Some(client) => client,
         None => {
-            txn.new_client(client_key, NO_VERSION_ID)
+            txn.new_client(client_key, NIL_VERSION_ID)
                 .map_err(failure_to_ise)?;
             txn.get_client(client_key).map_err(failure_to_ise)?.unwrap()
         }
@@ -81,7 +81,7 @@ mod test {
         {
             let mut txn = storage.txn().unwrap();
             txn.new_client(client_key, version_id).unwrap();
-            txn.add_version(client_key, version_id, NO_VERSION_ID, vec![])?;
+            txn.add_version(client_key, version_id, NIL_VERSION_ID, vec![])?;
         }
 
         let server = Server::new(storage);
@@ -122,7 +122,7 @@ mod test {
         // set up the storage contents..
         {
             let mut txn = storage.txn().unwrap();
-            txn.new_client(client_key, NO_VERSION_ID).unwrap();
+            txn.new_client(client_key, NIL_VERSION_ID).unwrap();
         }
 
         let server = Server::new(storage);

--- a/sync-server/src/api/add_version.rs
+++ b/sync-server/src/api/add_version.rs
@@ -2,7 +2,7 @@ use crate::api::{
     client_key_header, failure_to_ise, ServerState, HISTORY_SEGMENT_CONTENT_TYPE,
     PARENT_VERSION_ID_HEADER, SNAPSHOT_REQUEST_HEADER, VERSION_ID_HEADER,
 };
-use crate::server::{add_version, AddVersionResult, SnapshotUrgency, VersionId, NO_VERSION_ID};
+use crate::server::{add_version, AddVersionResult, SnapshotUrgency, VersionId, NIL_VERSION_ID};
 use actix_web::{error, post, web, HttpMessage, HttpRequest, HttpResponse, Result};
 use futures::StreamExt;
 
@@ -60,7 +60,7 @@ pub(crate) async fn service(
     let client = match txn.get_client(client_key).map_err(failure_to_ise)? {
         Some(client) => client,
         None => {
-            txn.new_client(client_key, NO_VERSION_ID)
+            txn.new_client(client_key, NIL_VERSION_ID)
                 .map_err(failure_to_ise)?;
             txn.get_client(client_key).map_err(failure_to_ise)?.unwrap()
         }

--- a/sync-server/src/api/get_child_version.rs
+++ b/sync-server/src/api/get_child_version.rs
@@ -47,7 +47,7 @@ pub(crate) async fn service(
 
 #[cfg(test)]
 mod test {
-    use crate::server::NO_VERSION_ID;
+    use crate::server::NIL_VERSION_ID;
     use crate::storage::{InMemoryStorage, Storage};
     use crate::Server;
     use actix_web::{http::StatusCode, test, App};
@@ -144,7 +144,7 @@ mod test {
         // but the child of the nil parent_version_id is NOT FOUND, since
         // there is no snapshot.  The tests in crate::server test more
         // corner cases.
-        let uri = format!("/v1/client/get-child-version/{}", NO_VERSION_ID);
+        let uri = format!("/v1/client/get-child-version/{}", NIL_VERSION_ID);
         let req = test::TestRequest::get()
             .uri(&uri)
             .header("X-Client-Key", client_key.to_string())


### PR DESCRIPTION
The docs refer to this as the "nil version ID" so let's do the same.

This started out more ambitiously, to change this to `VersionId::NIL`,
but that required making VersionId a newtype and all of the implicit
conversions from VersionId to Uuid would have to be explicit.  That
didn't seem wortht the trouble.