### PR TITLE
Support taskdb truncation

### DIFF
--- a/taskchampion/src/storage/mod.rs
+++ b/taskchampion/src/storage/mod.rs
@@ -105,6 +105,9 @@ pub trait StorageTxn {
     /// Note that this is the only way items are removed from the set.
     fn clear_working_set(&mut self) -> Result<()>;
 
+    /// Clear the entire taskdb.
+    fn truncate(&mut self) -> Result<()>;
+
     /// Commit any changes made in the transaction.  It is an error to call this more than
     /// once.
     fn commit(&mut self) -> Result<()>;


### PR DESCRIPTION
In the process of working on client-side support for snapshots, I thought I wanted this.  Then I changed my mind.  But, maybe we will want it after all?  Here as a draft for now :)