### PR TITLE
do not run audit on PRs

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -7,7 +7,6 @@ on:
     paths:
       - '**/Cargo.toml'
       - '**/Cargo.lock'
-  pull_request:
 
 jobs:
   audit:


### PR DESCRIPTION
This still runs on merges to main and every day.  But it's not adding useful information to a PR, especially with #304 currently unsolvable.