### PR TITLE
Add config for cargo-audit

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -1,4 +1,5 @@
 [advisories]
 ignore = [
     "RUSTSEC-2020-0159", # segfault in localtime_r - low risk to TC
+    "RUSTSEC-2020-0071", # same localtime_r bug as above
 ]


### PR DESCRIPTION
Relating to #304

Might also play around with making the audit run a scheduled check as per https://github.com/actions-rs/audit-check#scheduled-audit as it seems very unlikely to ever be useful to have this fail on a PR