### PR TITLE
Add support for annotations

### DIFF
--- a/cli/src/argparse/modification.rs
+++ b/cli/src/argparse/modification.rs
@@ -48,6 +48,9 @@ pub struct Modification {
 
     /// Remove tags
     pub remove_tags: HashSet<Tag>,
+
+    /// Add annotation
+    pub annotate: Option<String>,
 }
 
 /// A single argument that is part of a modification, used internally to this module
@@ -128,12 +131,12 @@ impl Modification {
     pub(super) fn get_usage(u: &mut usage::Usage) {
         u.modifications.push(usage::Modification {
             syntax: "DESCRIPTION",
-            summary: "Set description",
+            summary: "Set description/annotation",
             description: "
-                Set the task description.  Multiple arguments are combined into a single
-                space-separated description.  To avoid surprises from shell quoting, prefer
-                to use a single quoted argument, for example `ta 19 modify \"return library
-                books\"`",
+                Set the task description (or the task annotation for `ta annotate`).  Multiple
+                arguments are combined into a single space-separated description.  To avoid
+                surprises from shell quoting, prefer to use a single quoted argument, for example
+                `ta 19 modify \"return library books\"`",
         });
         u.modifications.push(usage::Modification {
             syntax: "+TAG",

--- a/cli/src/invocation/cmd/info.rs
+++ b/cli/src/invocation/cmd/info.rs
@@ -39,6 +39,11 @@ pub(crate) fn execute<W: WriteColor>(
             if let Some(wait) = task.get_wait() {
                 t.add_row(row![b->"Wait", wait]);
             }
+            let mut annotations: Vec<_> = task.get_annotations().collect();
+            annotations.sort();
+            for ann in annotations {
+                t.add_row(row![b->"Annotation", format!("{}: {}", ann.entry, ann.description)]);
+            }
         }
         t.print(w)?;
     }

--- a/cli/src/invocation/modify.rs
+++ b/cli/src/invocation/modify.rs
@@ -1,5 +1,6 @@
 use crate::argparse::{DescriptionMod, Modification};
-use taskchampion::TaskMut;
+use chrono::Utc;
+use taskchampion::{Annotation, TaskMut};
 
 /// Apply the given modification
 pub(super) fn apply_modification(
@@ -39,6 +40,13 @@ pub(super) fn apply_modification(
 
     if let Some(wait) = modification.wait {
         task.set_wait(wait)?;
+    }
+
+    if let Some(ref ann) = modification.annotate {
+        task.add_annotation(Annotation {
+            entry: Utc::now(),
+            description: ann.into(),
+        })?;
     }
 
     Ok(())

--- a/docs/src/tasks.md
+++ b/docs/src/tasks.md
@@ -33,8 +33,8 @@ The following keys, and key formats, are defined:
 * `start` - the most recent time at which this task was started (a task with no `start` key is not active)
 * `tag.<tag>` - indicates this task has tag `<tag>` (value is an empty string)
 * `wait` - indicates the time before which this task should be hidden, as it is not actionable
+* `annotation_<timestamp>` - value is an annotation created at the given time
 
 The following are not yet implemented:
 
-* `dep.<uuid>` - indicates this task depends on `<uuid>` (value is an empty string)
-* `annotation.<timestamp>` - value is an annotation created at the given time
+* `dep_<uuid>` - indicates this task depends on `<uuid>` (value is an empty string)

--- a/taskchampion/src/lib.rs
+++ b/taskchampion/src/lib.rs
@@ -58,7 +58,7 @@ pub use errors::Error;
 pub use replica::Replica;
 pub use server::{Server, ServerConfig};
 pub use storage::StorageConfig;
-pub use task::{Priority, Status, Tag, Task, TaskMut};
+pub use task::{Annotation, Priority, Status, Tag, Task, TaskMut};
 pub use workingset::WorkingSet;
 
 /// Re-exported type from the `uuid` crate, for ease of compatibility for consumers of this crate.

--- a/taskchampion/src/task/annotation.rs
+++ b/taskchampion/src/task/annotation.rs
@@ -1,7 +1,7 @@
 use super::Timestamp;
 
 /// An annotation for a task
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord)]
 pub struct Annotation {
     /// Time the annotation was made
     pub entry: Timestamp,


### PR DESCRIPTION
This matches the taskwarrior task model for annotations.

Note that I didn't support `ta denotate`.  If we feel that's necessary, we can make an issue to do it in a followup (outside of 0.5.0).