### PR TITLE
Update clippy toolchain to 1.57

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -31,7 +31,7 @@ jobs:
         with:
           # Fixed version for clippy lints.  Bump this as necesary.  It must not
           # be older than the MSRV in tests.yml.
-          toolchain: "1.54"
+          toolchain: "1.57"
           override: true
 
       - uses: actions-rs/cargo@v1.0.1


### PR DESCRIPTION
It looks like we were just using an older clippy?

```
funk ~/p/taskchampion [issue322*] $ cargo clean 
funk ~/p/taskchampion [issue322*] $ cargo clippy 
   Compiling libc v0.2.97              
   Compiling proc-macro2 v1.0.27      
...
   Compiling built v0.5.1
    Checking replica-server-tests v0.4.1 (/home/dustin/p/taskchampion/replica-server-tests)
   Compiling taskchampion-cli v0.4.1 (/home/dustin/p/taskchampion/cli)
    Finished dev [unoptimized + debuginfo] target(s) in 1m 44s
funk ~/p/taskchampion [issue322] $ cargo version
cargo 1.57.0 (b2e52d7ca 2021-10-21)
```