### PR TITLE
Support an 'end' key in task maps

### DIFF
--- a/docs/src/tasks.md
+++ b/docs/src/tasks.md
@@ -17,6 +17,12 @@ The result of this reconciliation will be `oldtag,newtag2`, while the user almos
 
 The key names given below avoid this issue, allowing user updates such as adding a tag or deleting a dependency to be represented in a single `Update` operation.
 
+## Validity
+
+_Any_ key/value map is a valid task.
+Consumers of task data must make a best effort to interpret any map, even if it contains apparently contradictory information.
+For example, a task with status "completed" but no "end" key present should be interpreted as completed at an unknown time.
+
 ## Representations
 
 Integers are stored in decimal notation.
@@ -31,6 +37,7 @@ The following keys, and key formats, are defined:
 * `description` - the one-line summary of the task
 * `modified` - the time of the last modification of this task
 * `start` - the most recent time at which this task was started (a task with no `start` key is not active)
+* `end` - if present, the time at which this task was completed or deleted (note that this key may not agree with `status`: it may be present for a pending task, or absent for a deleted or completed task)
 * `tag_<tag>` - indicates this task has tag `<tag>` (value is an empty string)
 * `wait` - indicates the time before which this task should be hidden, as it is not actionable
 * `annotation_<timestamp>` - value is an annotation created at the given time

--- a/taskchampion/src/replica.rs
+++ b/taskchampion/src/replica.rs
@@ -228,7 +228,7 @@ mod tests {
                 ..
             } = op
             {
-                if property == "modified" {
+                if property == "modified" || property == "end" {
                     if value.is_some() {
                         value = Some("just-now".into());
                     }
@@ -289,6 +289,13 @@ mod tests {
                     property: "description".into(),
                     old_value: Some("a task".into()),
                     value: Some("past tense".into()),
+                    timestamp: now,
+                },
+                ReplicaOp::Update {
+                    uuid: t.get_uuid(),
+                    property: "end".into(),
+                    old_value: None,
+                    value: Some("just-now".into()),
                     timestamp: now,
                 },
                 ReplicaOp::Update {

--- a/taskchampion/src/task/task.rs
+++ b/taskchampion/src/task/task.rs
@@ -265,7 +265,6 @@ impl<'r> TaskMut<'r> {
     /// Set the task's status.  This also adds the task to the working set if the
     /// new status puts it in that set.
     pub fn set_status(&mut self, status: Status) -> anyhow::Result<()> {
-        if status == Status::Pending {}
         match status {
             Status::Pending => {
                 // clear "end" when a task becomes "pending"


### PR DESCRIPTION
This definition matches how TaskWarrior uses the same key.

Fixes #327.