### PR TITLE
Add support for dependencies

### DIFF
--- a/cli/src/argparse/args/idlist.rs
+++ b/cli/src/argparse/args/idlist.rs
@@ -2,7 +2,7 @@ use nom::{branch::*, character::complete::*, combinator::*, multi::*, sequence::
 use taskchampion::Uuid;
 
 /// A task identifier, as given in a filter command-line expression
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, PartialEq, Eq, Hash, Clone)]
 pub(crate) enum TaskId {
     /// A small integer identifying a working-set task
     WorkingSetId(usize),

--- a/cli/src/argparse/args/mod.rs
+++ b/cli/src/argparse/args/mod.rs
@@ -8,7 +8,7 @@ mod tags;
 mod time;
 
 pub(crate) use arg_matching::arg_matching;
-pub(crate) use colon::{status_colon, wait_colon};
+pub(crate) use colon::{depends_colon, status_colon, wait_colon};
 pub(crate) use idlist::{id_list, TaskId};
 pub(crate) use misc::{any, literal, report_name};
 pub(crate) use tags::{minus_tag, plus_tag};

--- a/cli/src/invocation/cmd/modify.rs
+++ b/cli/src/invocation/cmd/modify.rs
@@ -1,6 +1,6 @@
-use crate::argparse::{Filter, Modification};
+use crate::argparse::Filter;
 use crate::invocation::util::{confirm, summarize_task};
-use crate::invocation::{apply_modification, filtered_tasks};
+use crate::invocation::{apply_modification, filtered_tasks, ResolvedModification};
 use crate::settings::Settings;
 use taskchampion::Replica;
 use termcolor::WriteColor;
@@ -39,12 +39,12 @@ fn check_modification<W: WriteColor>(
     Ok(false)
 }
 
-pub(crate) fn execute<W: WriteColor>(
+pub(in crate::invocation) fn execute<W: WriteColor>(
     w: &mut W,
     replica: &mut Replica,
     settings: &Settings,
     filter: Filter,
-    modification: Modification,
+    modification: ResolvedModification,
 ) -> Result<(), crate::Error> {
     let tasks = filtered_tasks(replica, &filter)?;
 
@@ -68,7 +68,7 @@ pub(crate) fn execute<W: WriteColor>(
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::argparse::DescriptionMod;
+    use crate::argparse::{DescriptionMod, Modification};
     use crate::invocation::test::test_replica;
     use crate::invocation::test::*;
     use pretty_assertions::assert_eq;
@@ -87,10 +87,10 @@ mod test {
         let filter = Filter {
             ..Default::default()
         };
-        let modification = Modification {
+        let modification = ResolvedModification(Modification {
             description: DescriptionMod::Set(s!("new description")),
             ..Default::default()
-        };
+        });
         execute(&mut w, &mut replica, &settings, filter, modification).unwrap();
 
         // check that the task appeared..

--- a/cli/src/invocation/mod.rs
+++ b/cli/src/invocation/mod.rs
@@ -15,7 +15,7 @@ mod util;
 mod test;
 
 use filter::filtered_tasks;
-use modify::apply_modification;
+use modify::{apply_modification, resolve_modification, ResolvedModification};
 use report::display_report;
 
 /// Invoke the given Command in the context of the given settings
@@ -52,7 +52,10 @@ pub(crate) fn invoke(command: Command, settings: Settings) -> Result<(), crate::
         Command {
             subcommand: Subcommand::Add { modification },
             ..
-        } => return cmd::add::execute(&mut w, &mut replica, modification),
+        } => {
+            let modification = resolve_modification(modification, &mut replica)?;
+            return cmd::add::execute(&mut w, &mut replica, modification);
+        }
 
         Command {
             subcommand:
@@ -61,7 +64,10 @@ pub(crate) fn invoke(command: Command, settings: Settings) -> Result<(), crate::
                     modification,
                 },
             ..
-        } => return cmd::modify::execute(&mut w, &mut replica, &settings, filter, modification),
+        } => {
+            let modification = resolve_modification(modification, &mut replica)?;
+            return cmd::modify::execute(&mut w, &mut replica, &settings, filter, modification);
+        }
 
         Command {
             subcommand:

--- a/cli/src/invocation/modify.rs
+++ b/cli/src/invocation/modify.rs
@@ -1,12 +1,97 @@
-use crate::argparse::{DescriptionMod, Modification};
+use crate::argparse::{DescriptionMod, Modification, TaskId};
+use std::collections::HashSet;
 use taskchampion::chrono::Utc;
-use taskchampion::{Annotation, TaskMut};
+use taskchampion::{Annotation, Replica, TaskMut};
+
+/// A wrapper for Modification, promising that all TaskId instances are of variant TaskId::Uuid.
+pub(super) struct ResolvedModification(pub(super) Modification);
+
+/// Resolve a Modification to a ResolvedModification, based on access to a Replica.
+///
+/// This is not automatically done in `apply_modification` because, by that time, the TaskMut being
+/// modified has an exclusive reference to the Replica, so it is impossible to search for matching
+/// tasks.
+pub(super) fn resolve_modification(
+    unres: Modification,
+    replica: &mut Replica,
+) -> anyhow::Result<ResolvedModification> {
+    Ok(ResolvedModification(Modification {
+        description: unres.description,
+        status: unres.status,
+        wait: unres.wait,
+        active: unres.active,
+        add_tags: unres.add_tags,
+        remove_tags: unres.remove_tags,
+        add_dependencies: resolve_task_ids(replica, unres.add_dependencies)?,
+        remove_dependencies: resolve_task_ids(replica, unres.remove_dependencies)?,
+        annotate: unres.annotate,
+    }))
+}
+
+/// Convert a set of arbitrary TaskId's into TaskIds containing only TaskId::Uuid.
+fn resolve_task_ids(
+    replica: &mut Replica,
+    task_ids: HashSet<TaskId>,
+) -> anyhow::Result<HashSet<TaskId>> {
+    // already all UUIDs (or empty)?
+    if task_ids.iter().all(|tid| matches!(tid, TaskId::Uuid(_))) {
+        return Ok(task_ids);
+    }
+
+    let mut result = HashSet::new();
+    let mut working_set = None;
+    let mut all_tasks = None;
+    for tid in task_ids {
+        match tid {
+            TaskId::WorkingSetId(i) => {
+                let ws = match working_set {
+                    Some(ref ws) => ws,
+                    None => {
+                        working_set = Some(replica.working_set()?);
+                        working_set.as_ref().unwrap()
+                    }
+                };
+                if let Some(u) = ws.by_index(i) {
+                    result.insert(TaskId::Uuid(u));
+                }
+            }
+            TaskId::PartialUuid(partial) => {
+                let ts = match all_tasks {
+                    Some(ref ts) => ts,
+                    None => {
+                        all_tasks = Some(
+                            replica
+                                .all_task_uuids()?
+                                .drain(..)
+                                .map(|u| (u, u.to_string()))
+                                .collect::<Vec<_>>(),
+                        );
+                        all_tasks.as_ref().unwrap()
+                    }
+                };
+                for (u, ustr) in ts {
+                    if ustr.starts_with(&partial) {
+                        result.insert(TaskId::Uuid(*u));
+                    }
+                }
+            }
+            TaskId::Uuid(u) => {
+                result.insert(TaskId::Uuid(u));
+            }
+        }
+    }
+
+    Ok(result)
+}
 
 /// Apply the given modification
 pub(super) fn apply_modification(
     task: &mut TaskMut,
-    modification: &Modification,
+    modification: &ResolvedModification,
 ) -> anyhow::Result<()> {
+    // unwrap the "Resolved" promise
+    let modification = &modification.0;
+
     match modification.description {
         DescriptionMod::Set(ref description) => task.set_description(description.clone())?,
         DescriptionMod::Prepend(ref description) => {
@@ -49,5 +134,114 @@ pub(super) fn apply_modification(
         })?;
     }
 
+    for tid in &modification.add_dependencies {
+        if let TaskId::Uuid(u) = tid {
+            task.add_dependency(*u)?;
+        } else {
+            // this Modification is resolved, so all TaskIds should
+            // be the Uuid variant.
+            unreachable!();
+        }
+    }
+
+    for tid in &modification.remove_dependencies {
+        if let TaskId::Uuid(u) = tid {
+            task.remove_dependency(*u)?;
+        } else {
+            // this Modification is resolved, so all TaskIds should
+            // be the Uuid variant.
+            unreachable!();
+        }
+    }
+
     Ok(())
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::invocation::test::*;
+    use pretty_assertions::assert_eq;
+    use taskchampion::{Status, Uuid};
+
+    #[test]
+    fn test_resolve_modifications() {
+        let mut replica = test_replica();
+        let u1 = Uuid::new_v4();
+        let t1 = replica.new_task(Status::Pending, "a task".into()).unwrap();
+        replica.rebuild_working_set(true).unwrap();
+
+        let modi = Modification {
+            add_dependencies: set![TaskId::Uuid(u1), TaskId::WorkingSetId(1)],
+            ..Default::default()
+        };
+
+        let res = resolve_modification(modi, &mut replica).unwrap();
+
+        assert_eq!(
+            res.0.add_dependencies,
+            set![TaskId::Uuid(u1), TaskId::Uuid(t1.get_uuid())],
+        );
+    }
+
+    #[test]
+    fn test_resolve_task_ids_empty() {
+        let mut replica = test_replica();
+
+        assert_eq!(
+            resolve_task_ids(&mut replica, HashSet::new()).unwrap(),
+            HashSet::new()
+        );
+    }
+
+    #[test]
+    fn test_resolve_task_ids_all_uuids() {
+        let mut replica = test_replica();
+        let uuid = Uuid::new_v4();
+        let tids = set![TaskId::Uuid(uuid)];
+        assert_eq!(resolve_task_ids(&mut replica, tids.clone()).unwrap(), tids);
+    }
+
+    #[test]
+    fn test_resolve_task_ids_working_set_not_found() {
+        let mut replica = test_replica();
+        let tids = set![TaskId::WorkingSetId(13)];
+        assert_eq!(
+            resolve_task_ids(&mut replica, tids.clone()).unwrap(),
+            HashSet::new()
+        );
+    }
+
+    #[test]
+    fn test_resolve_task_ids_working_set() {
+        let mut replica = test_replica();
+        let t1 = replica.new_task(Status::Pending, "a task".into()).unwrap();
+        let t2 = replica
+            .new_task(Status::Pending, "another task".into())
+            .unwrap();
+        replica.rebuild_working_set(true).unwrap();
+        let tids = set![TaskId::WorkingSetId(1), TaskId::WorkingSetId(2)];
+        let resolved = set![TaskId::Uuid(t1.get_uuid()), TaskId::Uuid(t2.get_uuid())];
+        assert_eq!(resolve_task_ids(&mut replica, tids).unwrap(), resolved);
+    }
+
+    #[test]
+    fn test_resolve_task_ids_partial_not_found() {
+        let mut replica = test_replica();
+        let tids = set![TaskId::PartialUuid("abcd".into())];
+        assert_eq!(
+            resolve_task_ids(&mut replica, tids.clone()).unwrap(),
+            HashSet::new()
+        );
+    }
+
+    #[test]
+    fn test_resolve_task_ids_partial() {
+        let mut replica = test_replica();
+        let t1 = replica.new_task(Status::Pending, "a task".into()).unwrap();
+        let uuid_str = t1.get_uuid().to_string();
+        let tids = set![TaskId::PartialUuid(uuid_str[..8].into())];
+        let resolved = set![TaskId::Uuid(t1.get_uuid())];
+        assert_eq!(resolve_task_ids(&mut replica, tids).unwrap(), resolved);
+    }
 }

--- a/cli/src/invocation/report.rs
+++ b/cli/src/invocation/report.rs
@@ -406,9 +406,12 @@ mod test {
         let task = replica.get_task(uuids[0]).unwrap().unwrap();
         assert_eq!(
             task_column(&task, &column, &working_set),
-            s!("+PENDING +bar +foo")
+            s!("+PENDING +UNBLOCKED +bar +foo")
         );
         let task = replica.get_task(uuids[2]).unwrap().unwrap();
-        assert_eq!(task_column(&task, &column, &working_set), s!("+PENDING"));
+        assert_eq!(
+            task_column(&task, &column, &working_set),
+            s!("+PENDING +UNBLOCKED")
+        );
     }
 }

--- a/cli/src/macros.rs
+++ b/cli/src/macros.rs
@@ -12,6 +12,7 @@ macro_rules! argv {
 }
 
 /// Create a hashset, similar to vec!
+// NOTE: in Rust 1.56.0, this can be changed to HashSet::from([..])
 #[cfg(test)]
 macro_rules! set(
     { $($key:expr),+ } => {

--- a/cli/src/macros.rs
+++ b/cli/src/macros.rs
@@ -15,12 +15,13 @@ macro_rules! argv {
 // NOTE: in Rust 1.56.0, this can be changed to HashSet::from([..])
 #[cfg(test)]
 macro_rules! set(
-    { $($key:expr),+ } => {
+    { $($key:expr),* $(,)? } => {
         {
+            #[allow(unused_mut)]
             let mut s = ::std::collections::HashSet::new();
             $(
                 s.insert($key);
-            )+
+            )*
             s
         }
      };

--- a/lib/taskchampion.h
+++ b/lib/taskchampion.h
@@ -912,6 +912,21 @@ TCResult tc_task_set_legacy_uda(struct TCTask *task, struct TCString key, struct
 TCResult tc_task_remove_legacy_uda(struct TCTask *task, struct TCString key);
 
 /**
+ * Get all dependencies for a task.
+ */
+struct TCUuidList tc_task_get_dependencies(struct TCTask *task);
+
+/**
+ * Add a dependency.
+ */
+TCResult tc_task_add_dependency(struct TCTask *task, struct TCUuid dep);
+
+/**
+ * Remove a dependency.
+ */
+TCResult tc_task_remove_dependency(struct TCTask *task, struct TCUuid dep);
+
+/**
  * Get the latest error for a task, or a string NULL ptr field if the last operation succeeded.
  * Subsequent calls to this function will return NULL.  The task pointer must not be NULL.  The
  * caller must free the returned string.

--- a/taskchampion/src/depmap.rs
+++ b/taskchampion/src/depmap.rs
@@ -1,0 +1,81 @@
+use uuid::Uuid;
+
+/// DependencyMap stores information on task dependencies between pending tasks.
+///
+/// This information requires a scan of the working set to generate, so it is
+/// typically calculated once and re-used.
+#[derive(Debug, PartialEq)]
+pub struct DependencyMap {
+    /// Edges of the dependency graph.  If (a, b) is in this array, then task a depends on tsak b.
+    edges: Vec<(Uuid, Uuid)>,
+}
+
+impl DependencyMap {
+    /// Create a new, empty DependencyMap.
+    pub(super) fn new() -> Self {
+        Self { edges: Vec::new() }
+    }
+
+    /// Add a dependency of a on b.
+    pub(super) fn add_dependency(&mut self, a: Uuid, b: Uuid) {
+        self.edges.push((a, b));
+    }
+
+    /// Return an iterator of Uuids on which task `deps_of` depends.  This is equivalent to
+    /// `task.get_dependencies()`.
+    pub fn dependencies(&self, dep_of: Uuid) -> impl Iterator<Item = Uuid> + '_ {
+        self.edges
+            .iter()
+            .filter_map(move |(a, b)| if a == &dep_of { Some(*b) } else { None })
+    }
+
+    /// Return an iterator of Uuids of tasks that depend on `dep_on`
+    /// `task.get_dependencies()`.
+    pub fn dependents(&self, dep_on: Uuid) -> impl Iterator<Item = Uuid> + '_ {
+        self.edges
+            .iter()
+            .filter_map(move |(a, b)| if b == &dep_on { Some(*a) } else { None })
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use pretty_assertions::assert_eq;
+    use std::collections::HashSet;
+
+    #[test]
+    fn dependencies() {
+        let t = Uuid::new_v4();
+        let uuid1 = Uuid::new_v4();
+        let uuid2 = Uuid::new_v4();
+        let mut dm = DependencyMap::new();
+
+        dm.add_dependency(t, uuid1);
+        dm.add_dependency(t, uuid2);
+        dm.add_dependency(Uuid::new_v4(), t);
+        dm.add_dependency(Uuid::new_v4(), uuid1);
+        dm.add_dependency(uuid2, Uuid::new_v4());
+
+        assert_eq!(
+            dm.dependencies(t).collect::<HashSet<_>>(),
+            set![uuid1, uuid2]
+        );
+    }
+
+    #[test]
+    fn dependents() {
+        let t = Uuid::new_v4();
+        let uuid1 = Uuid::new_v4();
+        let uuid2 = Uuid::new_v4();
+        let mut dm = DependencyMap::new();
+
+        dm.add_dependency(uuid1, t);
+        dm.add_dependency(uuid2, t);
+        dm.add_dependency(t, Uuid::new_v4());
+        dm.add_dependency(Uuid::new_v4(), uuid1);
+        dm.add_dependency(uuid2, Uuid::new_v4());
+
+        assert_eq!(dm.dependents(t).collect::<HashSet<_>>(), set![uuid1, uuid2]);
+    }
+}

--- a/taskchampion/src/lib.rs
+++ b/taskchampion/src/lib.rs
@@ -45,6 +45,10 @@ This crate supports Rust version 1.47 and higher.
 
  */
 
+// NOTE: it's important that this 'mod' comes first so that the macros can be used in other modules
+mod macros;
+
+mod depmap;
 mod errors;
 mod replica;
 pub mod server;
@@ -54,6 +58,7 @@ mod taskdb;
 mod utils;
 mod workingset;
 
+pub use depmap::DependencyMap;
 pub use errors::Error;
 pub use replica::Replica;
 pub use server::{Server, ServerConfig};

--- a/taskchampion/src/macros.rs
+++ b/taskchampion/src/macros.rs
@@ -1,0 +1,17 @@
+#![macro_use]
+
+/// Create a hashset, similar to vec!
+// NOTE: in Rust 1.56.0, this can be changed to HashSet::from([..])
+#[cfg(test)]
+macro_rules! set(
+    { $($key:expr),* $(,)? } => {
+        {
+            #[allow(unused_mut)]
+            let mut s = ::std::collections::HashSet::new();
+            $(
+                s.insert($key);
+            )*
+            s
+        }
+     };
+);

--- a/taskchampion/src/task/tag.rs
+++ b/taskchampion/src/task/tag.rs
@@ -134,6 +134,9 @@ pub(super) enum SyntheticTag {
     Pending,
     Completed,
     Deleted,
+    Blocked,
+    Unblocked,
+    Blocking,
 }
 
 #[cfg(test)]


### PR DESCRIPTION
The TC API part of this is, so far, pretty simple.  Supporting modifications in the CLI was a little harder, as it requires "resolving" things like "depends:5" to a UUID, which requires a replica.  But that wasn't too bad, either.

The vritual tags support has me a little stumped, though.  +BLOCKED requires looking at the depended-on task to see if it's still pending.  That's not so bad, but requires a reference to the replica, which most `Task` methods do not (`TaskMut` does, but this isn't a mutation..).  +BLOCKING is even worse, though: it requires, I think, a full scan of the taskdb.

I'll look at how TaskWarrior implements these things.