### PR TITLE
use TC_UUID_STRING_BYTES constant directly

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3039,7 +3039,6 @@ dependencies = [
  "libc",
  "pretty_assertions",
  "taskchampion",
- "uuid",
 ]
 
 [[package]]

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -11,7 +11,6 @@ crate-type = ["staticlib", "cdylib"]
 libc = "0.2.113"
 chrono = "^0.4.10"
 taskchampion = { path = "../taskchampion" }
-uuid = { version = "^0.8.2", features = ["v4"] }
 anyhow = "1.0"
 
 [dev-dependencies]

--- a/lib/src/uuid.rs
+++ b/lib/src/uuid.rs
@@ -87,9 +87,8 @@ pub unsafe extern "C" fn tc_uuid_to_buf(tcuuid: TCUuid, buf: *mut libc::c_char) 
     //  - content of buf will not be mutated during the lifetime of this slice (lifetime
     //    does not outlive this function call)
     //  - the length of the buffer is less than isize::MAX (promised by caller)
-    let buf: &mut [u8] = unsafe {
-        std::slice::from_raw_parts_mut(buf as *mut u8, ::uuid::adapter::Hyphenated::LENGTH)
-    };
+    let buf: &mut [u8] =
+        unsafe { std::slice::from_raw_parts_mut(buf as *mut u8, TC_UUID_STRING_BYTES) };
     // SAFETY:
     //  - tcuuid is a valid TCUuid (all byte patterns are valid)
     let uuid: Uuid = unsafe { TCUuid::val_from_arg(tcuuid) };


### PR DESCRIPTION
I spotted this while poking around elsewhere -- taskchampion-lib exposes a literal constant so that cbindgen can reflect its value into the header file.  But it was using a constant from the uuid crate in the code.  They had the same value, so it didn't make a big difference, but (a) this is cleaner and (b) this avoids taskchampion-lib requiring uuid directly.