### PR TITLE
Add support for expiration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1528,6 +1528,7 @@ dependencies = [
  "actix-web",
  "anyhow",
  "cc",
+ "chrono",
  "env_logger 0.8.4",
  "lazy_static",
  "log",

--- a/cli/src/argparse/subcommand.rs
+++ b/cli/src/argparse/subcommand.rs
@@ -218,6 +218,7 @@ impl Modify {
                 "start" => modification.active = Some(true),
                 "stop" => modification.active = Some(false),
                 "done" => modification.status = Some(Status::Completed),
+                "delete" => modification.status = Some(Status::Deleted),
                 "annotate" => {
                     // what would be parsed as a description is, here, used as the annotation
                     if let DescriptionMod::Set(s) = modification.description {
@@ -243,6 +244,7 @@ impl Modify {
                     arg_matching(literal("start")),
                     arg_matching(literal("stop")),
                     arg_matching(literal("done")),
+                    arg_matching(literal("delete")),
                     arg_matching(literal("annotate")),
                 )),
                 Modification::parse,
@@ -298,9 +300,18 @@ impl Modify {
                 modifications.",
         });
         u.subcommands.push(usage::Subcommand {
+            name: "delete",
+            syntax: "<filter> delete [modification]",
+            summary: "Mark tasks as deleted",
+            description: "
+                Mark all tasks matching the required filter as deleted, additionally applying any given
+                modifications.  Deleted tasks remain until they are expired in a 'ta gc' operation at
+                least six months after their last modification.",
+        });
+        u.subcommands.push(usage::Subcommand {
             name: "annotate",
             syntax: "<filter> annotate [modification]",
-            summary: "Mark tasks as completed",
+            summary: "Annotate a task",
             description: "
                 Add an annotation to all tasks matching the required filter.",
         });
@@ -757,6 +768,23 @@ mod test {
         };
         assert_eq!(
             Subcommand::parse(argv!["123", "stop", "mod"]).unwrap(),
+            (&EMPTY[..], subcommand)
+        );
+    }
+
+    #[test]
+    fn test_delete() {
+        let subcommand = Subcommand::Modify {
+            filter: Filter {
+                conditions: vec![Condition::IdList(vec![TaskId::WorkingSetId(123)])],
+            },
+            modification: Modification {
+                status: Some(Status::Deleted),
+                ..Default::default()
+            },
+        };
+        assert_eq!(
+            Subcommand::parse(argv!["123", "delete"]).unwrap(),
             (&EMPTY[..], subcommand)
         );
     }

--- a/cli/src/invocation/cmd/gc.rs
+++ b/cli/src/invocation/cmd/gc.rs
@@ -4,6 +4,8 @@ use termcolor::WriteColor;
 pub(crate) fn execute<W: WriteColor>(w: &mut W, replica: &mut Replica) -> Result<(), crate::Error> {
     log::debug!("rebuilding working set");
     replica.rebuild_working_set(true)?;
+    log::debug!("expiring old tasks");
+    replica.expire_tasks()?;
     writeln!(w, "garbage collected.")?;
     Ok(())
 }

--- a/docs/src/taskdb.md
+++ b/docs/src/taskdb.md
@@ -25,4 +25,8 @@ Operations are described in [Replica Storage](./storage.md).
 Each operation is added to the list of operations in the storage, and simultaneously applied to the tasks in that storage.
 Operations are checked for validity as they are applied.
 
+## Deletion and Expiration
 
+Deletion of a task merely changes the task's status to "deleted", leaving it in the Task database.
+Actual removal of tasks from the task database takes place as part of _expiration_, triggered by the user as part of a garbage-collection process.
+Expiration removes tasks with a `modified` property more than 180 days in the past, by creating a `Delete(uuid)` operation.

--- a/integration-tests/Cargo.toml
+++ b/integration-tests/Cargo.toml
@@ -7,6 +7,7 @@ publish = false
 build = "build.rs"
 
 [dependencies]
+chrono = { version = "^0.4.10", features = ["serde"] }
 taskchampion = { path = "../taskchampion" }
 taskchampion-sync-server = { path = "../sync-server" }
 

--- a/integration-tests/tests/update-and-delete-sync.rs
+++ b/integration-tests/tests/update-and-delete-sync.rs
@@ -1,0 +1,72 @@
+use chrono::{TimeZone, Utc};
+use taskchampion::{Replica, ServerConfig, Status, StorageConfig};
+use tempfile::TempDir;
+
+#[test]
+fn update_and_delete_sync_delete_first() -> anyhow::Result<()> {
+    update_and_delete_sync(true)
+}
+
+#[test]
+fn update_and_delete_sync_update_first() -> anyhow::Result<()> {
+    update_and_delete_sync(false)
+}
+
+/// Test what happens when an update is sync'd into a repo after a task is deleted.
+/// If delete_first, then the deletion is sync'd to the server first; otherwise
+/// the update is sync'd first.  Either way, the task is gone.
+fn update_and_delete_sync(delete_first: bool) -> anyhow::Result<()> {
+    // set up two replicas, and demonstrate replication between them
+    let mut rep1 = Replica::new(StorageConfig::InMemory.into_storage()?);
+    let mut rep2 = Replica::new(StorageConfig::InMemory.into_storage()?);
+
+    let tmp_dir = TempDir::new().expect("TempDir failed");
+    let mut server = ServerConfig::Local {
+        server_dir: tmp_dir.path().to_path_buf(),
+    }
+    .into_server()?;
+
+    // add a task on rep1, and sync it to rep2
+    let t = rep1.new_task(Status::Pending, "test task".into())?;
+    let u = t.get_uuid();
+
+    rep1.sync(&mut server, false)?;
+    rep2.sync(&mut server, false)?;
+
+    // mark the task as deleted, long in the past, on rep2
+    {
+        let mut t = rep2.get_task(u)?.unwrap().into_mut(&mut rep2);
+        t.delete()?;
+        t.set_modified(Utc.ymd(1980, 1, 1).and_hms(0, 0, 0))?;
+    }
+
+    // sync it back to rep1
+    rep2.sync(&mut server, false)?;
+    rep1.sync(&mut server, false)?;
+
+    // expire the task on rep1 and check that it is gone locally
+    rep1.expire_tasks()?;
+    assert!(rep1.get_task(u)?.is_none());
+
+    // modify the task on rep2
+    {
+        let mut t = rep2.get_task(u)?.unwrap().into_mut(&mut rep2);
+        t.set_description("modified".to_string())?;
+    }
+
+    // sync back and forth
+    if delete_first {
+        rep1.sync(&mut server, false)?;
+    }
+    rep2.sync(&mut server, false)?;
+    rep1.sync(&mut server, false)?;
+    if !delete_first {
+        rep2.sync(&mut server, false)?;
+    }
+
+    // check that the task is gone on both replicas
+    assert!(rep1.get_task(u)?.is_none());
+    assert!(rep2.get_task(u)?.is_none());
+
+    Ok(())
+}

--- a/taskchampion/src/task/task.rs
+++ b/taskchampion/src/task/task.rs
@@ -425,7 +425,7 @@ impl<'r> TaskMut<'r> {
 
     // -- utility functions
 
-    fn lastmod(&mut self) -> anyhow::Result<()> {
+    fn update_modified(&mut self) -> anyhow::Result<()> {
         if !self.updated_modified {
             let now = format!("{}", Utc::now().timestamp());
             trace!("task {}: set property modified={:?}", self.task.uuid, now);
@@ -443,7 +443,10 @@ impl<'r> TaskMut<'r> {
         value: Option<String>,
     ) -> anyhow::Result<()> {
         let property = property.into();
-        self.lastmod()?;
+        // updated the modified timestamp unless we are setting it explicitly
+        if &property != "modified" {
+            self.update_modified()?;
+        }
 
         if let Some(ref v) = value {
             trace!("task {}: set property {}={:?}", self.task.uuid, property, v);


### PR DESCRIPTION
This expires _deleted_ tasks 180 days after their last modification.

In most cases, users' tasks will stay around forever, as they are marked "completed" and not "deleted", but users who wish to keep their task list short can do something like `ta +COMPLETED delete` periodically.