### PR TITLE
Re-export the chrono crate from taskchampion.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1528,7 +1528,6 @@ dependencies = [
  "actix-web",
  "anyhow",
  "cc",
- "chrono",
  "env_logger 0.8.4",
  "lazy_static",
  "log",
@@ -3007,7 +3006,6 @@ dependencies = [
  "assert_cmd",
  "atty",
  "built",
- "chrono",
  "dialoguer",
  "dirs-next",
  "env_logger 0.8.4",
@@ -3036,7 +3034,6 @@ name = "taskchampion-lib"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "chrono",
  "libc",
  "pretty_assertions",
  "taskchampion",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -24,7 +24,6 @@ toml = "^0.5.8"
 toml_edit = "^0.2.0"
 serde = { version = "^1.0.125", features = ["derive"] }
 serde_json = "^1.0"
-chrono = { version = "^0.4.10", features = ["serde"] }
 lazy_static = "1"
 iso8601-duration = "0.1"
 dialoguer = "0.8"

--- a/cli/src/argparse/args/colon.rs
+++ b/cli/src/argparse/args/colon.rs
@@ -1,8 +1,8 @@
 use super::{any, timestamp};
 use crate::argparse::NOW;
-use chrono::prelude::*;
 use nom::bytes::complete::tag as nomtag;
 use nom::{branch::*, character::complete::*, combinator::*, sequence::*, IResult};
+use taskchampion::chrono::prelude::*;
 use taskchampion::Status;
 
 /// Recognizes up to the colon of the common `<prefix>:...` syntax
@@ -52,6 +52,7 @@ pub(crate) fn wait_colon(input: &str) -> IResult<&str, Option<DateTime<Utc>>> {
 mod test {
     use super::*;
     use pretty_assertions::assert_eq;
+    use taskchampion::chrono::Duration;
 
     #[test]
     fn test_colon_prefix() {
@@ -77,10 +78,10 @@ mod test {
     fn test_wait() {
         assert_eq!(wait_colon("wait:").unwrap(), ("", None));
 
-        let one_day = *NOW + chrono::Duration::days(1);
+        let one_day = *NOW + Duration::days(1);
         assert_eq!(wait_colon("wait:1d").unwrap(), ("", Some(one_day)));
 
-        let one_day = *NOW + chrono::Duration::days(1);
+        let one_day = *NOW + Duration::days(1);
         assert_eq!(wait_colon("wait:1d2").unwrap(), ("2", Some(one_day)));
     }
 }

--- a/cli/src/argparse/args/time.rs
+++ b/cli/src/argparse/args/time.rs
@@ -1,4 +1,3 @@
-use chrono::{prelude::*, Duration};
 use iso8601_duration::Duration as IsoDuration;
 use lazy_static::lazy_static;
 use nom::{
@@ -13,6 +12,7 @@ use nom::{
     Err, IResult,
 };
 use std::str::FromStr;
+use taskchampion::chrono::{self, prelude::*, Duration};
 
 // https://taskwarrior.org/docs/dates.html
 // https://taskwarrior.org/docs/named_dates.html

--- a/cli/src/argparse/mod.rs
+++ b/cli/src/argparse/mod.rs
@@ -31,8 +31,8 @@ pub(crate) use modification::{DescriptionMod, Modification};
 pub(crate) use subcommand::Subcommand;
 
 use crate::usage::Usage;
-use chrono::prelude::*;
 use lazy_static::lazy_static;
+use taskchampion::chrono::prelude::*;
 
 lazy_static! {
     // A static value of NOW to make tests easier

--- a/cli/src/argparse/modification.rs
+++ b/cli/src/argparse/modification.rs
@@ -1,9 +1,9 @@
 use super::args::{any, arg_matching, minus_tag, plus_tag, wait_colon};
 use super::ArgList;
 use crate::usage;
-use chrono::prelude::*;
 use nom::{branch::alt, combinator::*, multi::fold_many0, IResult};
 use std::collections::HashSet;
+use taskchampion::chrono::prelude::*;
 use taskchampion::{Status, Tag};
 
 #[derive(Debug, PartialEq, Clone)]
@@ -169,6 +169,7 @@ mod test {
     use super::*;
     use crate::argparse::NOW;
     use pretty_assertions::assert_eq;
+    use taskchampion::chrono::Duration;
 
     #[test]
     fn test_empty() {
@@ -215,7 +216,7 @@ mod test {
         assert_eq!(
             modification,
             Modification {
-                wait: Some(Some(*NOW + chrono::Duration::days(2))),
+                wait: Some(Some(*NOW + Duration::days(2))),
                 ..Default::default()
             }
         );

--- a/cli/src/invocation/cmd/import_tdb2.rs
+++ b/cli/src/invocation/cmd/import_tdb2.rs
@@ -84,9 +84,9 @@ fn import_task<W: WriteColor>(
 mod test {
     use super::*;
     use crate::invocation::test::*;
-    use chrono::{TimeZone, Utc};
     use pretty_assertions::assert_eq;
     use std::convert::TryInto;
+    use taskchampion::chrono::{TimeZone, Utc};
     use taskchampion::{Priority, Status};
     use tempfile::TempDir;
 

--- a/cli/src/invocation/cmd/import_tw.rs
+++ b/cli/src/invocation/cmd/import_tw.rs
@@ -1,8 +1,8 @@
 use anyhow::{anyhow, bail};
-use chrono::{DateTime, TimeZone, Utc};
 use serde::{self, Deserialize, Deserializer};
 use serde_json::Value;
 use std::collections::HashMap;
+use taskchampion::chrono::{DateTime, TimeZone, Utc};
 use taskchampion::{Replica, Uuid};
 use termcolor::{Color, ColorSpec, WriteColor};
 
@@ -152,10 +152,10 @@ fn import_task<W: WriteColor>(
 mod test {
     use super::*;
     use crate::invocation::test::*;
-    use chrono::{TimeZone, Utc};
     use pretty_assertions::assert_eq;
     use serde_json::json;
     use std::convert::TryInto;
+    use taskchampion::chrono::{TimeZone, Utc};
     use taskchampion::{Priority, Status};
 
     #[test]

--- a/cli/src/invocation/modify.rs
+++ b/cli/src/invocation/modify.rs
@@ -1,5 +1,5 @@
 use crate::argparse::{DescriptionMod, Modification};
-use chrono::Utc;
+use taskchampion::chrono::Utc;
 use taskchampion::{Annotation, TaskMut};
 
 /// Apply the given modification

--- a/cli/src/invocation/report.rs
+++ b/cli/src/invocation/report.rs
@@ -132,9 +132,9 @@ mod test {
     use super::*;
     use crate::invocation::test::*;
     use crate::settings::Sort;
-    use chrono::prelude::*;
     use pretty_assertions::assert_eq;
     use std::convert::TryInto;
+    use taskchampion::chrono::{prelude::*, Duration};
     use taskchampion::{Status, Uuid};
 
     fn create_tasks(replica: &mut Replica) -> [Uuid; 3] {
@@ -237,7 +237,7 @@ mod test {
             .unwrap()
             .unwrap()
             .into_mut(&mut replica)
-            .set_wait(Some(Utc::now() + chrono::Duration::days(2)))
+            .set_wait(Some(Utc::now() + Duration::days(2)))
             .unwrap();
 
         replica
@@ -245,7 +245,7 @@ mod test {
             .unwrap()
             .unwrap()
             .into_mut(&mut replica)
-            .set_wait(Some(Utc::now() + chrono::Duration::days(3)))
+            .set_wait(Some(Utc::now() + Duration::days(3)))
             .unwrap();
 
         let working_set = replica.working_set().unwrap();

--- a/integration-tests/Cargo.toml
+++ b/integration-tests/Cargo.toml
@@ -7,7 +7,6 @@ publish = false
 build = "build.rs"
 
 [dependencies]
-chrono = { version = "^0.4.10", features = ["serde"] }
 taskchampion = { path = "../taskchampion" }
 taskchampion-sync-server = { path = "../sync-server" }
 

--- a/integration-tests/tests/update-and-delete-sync.rs
+++ b/integration-tests/tests/update-and-delete-sync.rs
@@ -1,4 +1,4 @@
-use chrono::{TimeZone, Utc};
+use taskchampion::chrono::{TimeZone, Utc};
 use taskchampion::{Replica, ServerConfig, Status, StorageConfig};
 use tempfile::TempDir;
 

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -9,7 +9,6 @@ crate-type = ["staticlib", "cdylib"]
 
 [dependencies]
 libc = "0.2.113"
-chrono = "^0.4.10"
 taskchampion = { path = "../taskchampion" }
 anyhow = "1.0"
 

--- a/lib/src/annotation.rs
+++ b/lib/src/annotation.rs
@@ -1,6 +1,6 @@
 use crate::traits::*;
 use crate::types::*;
-use chrono::prelude::*;
+use taskchampion::chrono::prelude::*;
 
 /// TCAnnotation contains the details of an annotation.
 ///

--- a/lib/src/atomic.rs
+++ b/lib/src/atomic.rs
@@ -1,7 +1,7 @@
 //! Trait implementations for a few atomic types
 
 use crate::traits::*;
-use chrono::prelude::*;
+use taskchampion::chrono::prelude::*;
 
 impl PassByValue for usize {
     type RustType = usize;

--- a/lib/src/task.rs
+++ b/lib/src/task.rs
@@ -1,11 +1,11 @@
 use crate::traits::*;
 use crate::types::*;
 use crate::util::err_to_ruststring;
-use chrono::{TimeZone, Utc};
 use std::convert::TryFrom;
 use std::ops::Deref;
 use std::ptr::NonNull;
 use std::str::FromStr;
+use taskchampion::chrono::{TimeZone, Utc};
 use taskchampion::{Annotation, Tag, Task, TaskMut};
 
 /// A task, as publicly exposed by this library.

--- a/taskchampion/src/lib.rs
+++ b/taskchampion/src/lib.rs
@@ -63,3 +63,6 @@ pub use workingset::WorkingSet;
 
 /// Re-exported type from the `uuid` crate, for ease of compatibility for consumers of this crate.
 pub use uuid::Uuid;
+
+/// Re-exported chrono module.
+pub use chrono;


### PR DESCRIPTION
The chrono types are central to use of TC, so this will help consumers
of the TC crate to avoid dependency conflicts.