### PR TITLE
Allow taking from pointer lists

### DIFF
--- a/lib/src/annotation.rs
+++ b/lib/src/annotation.rs
@@ -75,13 +75,13 @@ pub struct TCAnnotationList {
 
     /// array of annotations. these remain owned by the TCAnnotationList instance and will be freed by
     /// tc_annotation_list_free.  This pointer is never NULL for a valid TCAnnotationList.
-    items: *const TCAnnotation,
+    items: *mut TCAnnotation,
 }
 
 impl CList for TCAnnotationList {
     type Element = TCAnnotation;
 
-    unsafe fn from_raw_parts(items: *const Self::Element, len: usize, cap: usize) -> Self {
+    unsafe fn from_raw_parts(items: *mut Self::Element, len: usize, cap: usize) -> Self {
         TCAnnotationList {
             len,
             _capacity: cap,
@@ -89,7 +89,16 @@ impl CList for TCAnnotationList {
         }
     }
 
-    fn into_raw_parts(self) -> (*const Self::Element, usize, usize) {
+    fn slice(&mut self) -> &mut [Self::Element] {
+        // SAFETY:
+        //  - because we have &mut self, we have read/write access to items[0..len]
+        //  - all items are properly initialized Element's
+        //  - return value lifetime is equal to &mmut self's, so access is exclusive
+        //  - items and len came from Vec, so total size is < isize::MAX
+        unsafe { std::slice::from_raw_parts_mut(self.items, self.len) }
+    }
+
+    fn into_raw_parts(self) -> (*mut Self::Element, usize, usize) {
         (self.items, self.len, self._capacity)
     }
 }

--- a/lib/src/kv.rs
+++ b/lib/src/kv.rs
@@ -50,13 +50,13 @@ pub struct TCKVList {
 
     /// array of TCKV's. these remain owned by the TCKVList instance and will be freed by
     /// tc_kv_list_free.  This pointer is never NULL for a valid TCKVList.
-    items: *const TCKV,
+    items: *mut TCKV,
 }
 
 impl CList for TCKVList {
     type Element = TCKV;
 
-    unsafe fn from_raw_parts(items: *const Self::Element, len: usize, cap: usize) -> Self {
+    unsafe fn from_raw_parts(items: *mut Self::Element, len: usize, cap: usize) -> Self {
         TCKVList {
             len,
             _capacity: cap,
@@ -64,7 +64,16 @@ impl CList for TCKVList {
         }
     }
 
-    fn into_raw_parts(self) -> (*const Self::Element, usize, usize) {
+    fn slice(&mut self) -> &mut [Self::Element] {
+        // SAFETY:
+        //  - because we have &mut self, we have read/write access to items[0..len]
+        //  - all items are properly initialized Element's
+        //  - return value lifetime is equal to &mmut self's, so access is exclusive
+        //  - items and len came from Vec, so total size is < isize::MAX
+        unsafe { std::slice::from_raw_parts_mut(self.items, self.len) }
+    }
+
+    fn into_raw_parts(self) -> (*mut Self::Element, usize, usize) {
         (self.items, self.len, self._capacity)
     }
 }

--- a/lib/src/replica.rs
+++ b/lib/src/replica.rs
@@ -177,12 +177,14 @@ pub unsafe extern "C" fn tc_replica_all_tasks(rep: *mut TCReplica) -> TCTaskList
                 .all_tasks()?
                 .drain()
                 .map(|(_uuid, t)| {
-                    NonNull::new(
-                        // SAFETY:
-                        // - caller promises to free this value (via freeing the list)
-                        unsafe { TCTask::from(t).return_ptr() },
+                    Some(
+                        NonNull::new(
+                            // SAFETY:
+                            // - caller promises to free this value (via freeing the list)
+                            unsafe { TCTask::from(t).return_ptr() },
+                        )
+                        .expect("TCTask::return_ptr returned NULL"),
                     )
-                    .expect("TCTask::return_ptr returned NULL")
                 })
                 .collect();
             // SAFETY:

--- a/lib/src/uda.rs
+++ b/lib/src/uda.rs
@@ -72,13 +72,13 @@ pub struct TCUdaList {
 
     /// array of UDAs. These remain owned by the TCUdaList instance and will be freed by
     /// tc_uda_list_free.  This pointer is never NULL for a valid TCUdaList.
-    items: *const TCUda,
+    items: *mut TCUda,
 }
 
 impl CList for TCUdaList {
     type Element = TCUda;
 
-    unsafe fn from_raw_parts(items: *const Self::Element, len: usize, cap: usize) -> Self {
+    unsafe fn from_raw_parts(items: *mut Self::Element, len: usize, cap: usize) -> Self {
         TCUdaList {
             len,
             _capacity: cap,
@@ -86,7 +86,16 @@ impl CList for TCUdaList {
         }
     }
 
-    fn into_raw_parts(self) -> (*const Self::Element, usize, usize) {
+    fn slice(&mut self) -> &mut [Self::Element] {
+        // SAFETY:
+        //  - because we have &mut self, we have read/write access to items[0..len]
+        //  - all items are properly initialized Element's
+        //  - return value lifetime is equal to &mmut self's, so access is exclusive
+        //  - items and len came from Vec, so total size is < isize::MAX
+        unsafe { std::slice::from_raw_parts_mut(self.items, self.len) }
+    }
+
+    fn into_raw_parts(self) -> (*mut Self::Element, usize, usize) {
         (self.items, self.len, self._capacity)
     }
 }


### PR DESCRIPTION
This introduces `tc_task_list_take`, supporting taking ownership of an
item in a task list.

TCTaskList is the only pointer list, but this is a generic and could be
used for other types.