### PR TITLE
export taskchampion-lib as an rlib, too

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,9 @@ To regenerate this file, run `cargo xtask codegen`.
 
 ## C libraries
 
+NOTE: support for linking against taskchampion is a work in progress.
+Contributions and pointers to best practices are appreciated!
+
 The `taskchampion-lib` crate generates libraries suitable for use from C (or any C-compatible language).
 
 The necessary bits are:
@@ -44,8 +47,12 @@ Downstream consumers may use either the static or dynamic library, as they prefe
 
 NOTE: on Windows, the "BCrypt" library must be included when linking to taskchampion.
 
+### As a Rust dependency
+
+If you would prefer to build Taskchampion directly into your project, and have a build system capable of building Rust libraries (such as CMake), the `taskchampion-lib` crate can be referenced as an `rlib` dependency.
+
 ## Documentation Generation
 
 The `mdbook` configuration contains a "preprocessor" implemented in the `taskchampion-cli` crate in order to reflect CLI usage information into the generated book.
-Tihs preprocessor is not built by default.
+This preprocessor is not built by default.
 To (re)build it, run `cargo build -p taskchampion-cli --features usage-docs --bin usage-docs`.

--- a/integration-tests/build.rs
+++ b/integration-tests/build.rs
@@ -18,7 +18,7 @@ fn link_libtaskchampion() {
 
     let libtc_dir = libtc_dir.to_str().expect("path is valid utf-8");
     println!("cargo:rustc-link-search={}", libtc_dir);
-    println!("cargo:rustc-link-lib=dylib=taskchampion");
+    println!("cargo:rustc-link-lib=dylib=taskchampionlib");
 
     // on windows, it appears that rust std requires BCrypt
     if cfg!(target_os = "windows") {

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2018"
 
 [lib]
-name = "taskchampion"
+name = "taskchampionlib"
 crate-type = ["staticlib", "cdylib", "rlib"]
 
 [dependencies]

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2018"
 
 [lib]
 name = "taskchampion"
-crate-type = ["staticlib", "cdylib"]
+crate-type = ["staticlib", "cdylib", "rlib"]
 
 [dependencies]
 libc = "0.2.113"

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -17,17 +17,29 @@ mod traits;
 mod util;
 
 pub mod annotation;
+pub use annotation::*;
 pub mod atomic;
+pub use atomic::*;
 pub mod kv;
+pub use kv::*;
 pub mod replica;
+pub use replica::*;
 pub mod result;
+pub use result::*;
 pub mod server;
+pub use server::*;
 pub mod status;
+pub use status::*;
 pub mod string;
+pub use string::*;
 pub mod task;
+pub use task::*;
 pub mod uda;
+pub use uda::*;
 pub mod uuid;
+pub use uuid::*;
 pub mod workingset;
+pub use workingset::*;
 
 pub(crate) mod types {
     pub(crate) use crate::annotation::{TCAnnotation, TCAnnotationList};

--- a/lib/src/string.rs
+++ b/lib/src/string.rs
@@ -411,7 +411,7 @@ impl CList for TCStringList {
 ///
 /// For example:
 ///
-/// ```
+/// ```text
 /// char *url = get_item_url(..); // dynamically allocate C string
 /// tc_task_annotate(task, tc_string_borrow(url)); // TCString created, passed, and freed
 /// free(url); // string is no longer referenced and can be freed


### PR DESCRIPTION
This puts all of the symbols at the top level, and publishes the crate as an rlib.

I suspect this will be the easiest way to make this C code available elsewhere?  At any rate, it was the simplest way I could find to integrate with Taskwarrior.