### PR TITLE
Fix sqlite on haiku

### DIFF
--- a/src/storage/sqlite/inner.rs
+++ b/src/storage/sqlite/inner.rs
@@ -97,6 +97,7 @@ impl SqliteStorageInner {
         let mut con = Connection::open_with_flags(db_file, flags)?;
 
         // Initialize database
+        #[cfg(not(target_os = "haiku"))]
         con.query_row("PRAGMA journal_mode=WAL", [], |_row| Ok(()))
             .context("Setting journal_mode=WAL")?;
 
@@ -484,6 +485,7 @@ mod test {
         let db_file = path.join("taskchampion.sqlite3");
         let con = Connection::open(db_file)?;
 
+        #[cfg(not(target_os = "haiku"))]
         con.query_row("PRAGMA journal_mode=WAL", [], |_row| Ok(()))
             .context("Setting journal_mode=WAL")?;
         let queries = vec![

--- a/src/storage/sqlite/mod.rs
+++ b/src/storage/sqlite/mod.rs
@@ -76,8 +76,8 @@ mod test {
     use tempfile::TempDir;
 
     async fn storage() -> Result<SqliteStorage> {
-        let tmp_dir = TempDir::new()?;
-        SqliteStorage::new(tmp_dir.path(), AccessMode::ReadWrite, true).await
+        let tmp_dir = TempDir::new()?.keep();
+        SqliteStorage::new(tmp_dir.as_path(), AccessMode::ReadWrite, true).await
     }
 
     crate::storage::test::storage_tests!(storage().await?);

--- a/src/storage/sqlite/mod.rs
+++ b/src/storage/sqlite/mod.rs
@@ -72,12 +72,14 @@ mod test {
     use super::*;
     use crate::errors::Error;
     use crate::storage::config::AccessMode;
+    use crate::storage::test::GuardedStorage;
     use pretty_assertions::assert_eq;
     use tempfile::TempDir;
 
-    async fn storage() -> Result<SqliteStorage> {
-        let tmp_dir = TempDir::new()?.keep();
-        SqliteStorage::new(tmp_dir.as_path(), AccessMode::ReadWrite, true).await
+    async fn storage() -> Result<impl Storage> {
+        let tmp_dir = TempDir::new()?;
+        let storage = SqliteStorage::new(tmp_dir.path(), AccessMode::ReadWrite, true).await?;
+        Ok(GuardedStorage::new(storage, tmp_dir))
     }
 
     crate::storage::test::storage_tests!(storage().await?);

--- a/src/storage/test.rs
+++ b/src/storage/test.rs
@@ -1,13 +1,37 @@
 //! Tests for storage backends. This tests consistency across multiple method calls, to ensure that
 //! all implementations are consistent.
 
-use super::{Storage, TaskMap};
+use super::{Storage, StorageTxn, TaskMap};
 use crate::errors::Result;
 use crate::storage::{taskmap_with, DEFAULT_BASE_VERSION};
 use crate::Operation;
+use async_trait::async_trait;
 use chrono::Utc;
 use pretty_assertions::assert_eq;
 use uuid::Uuid;
+
+/// Add a value to [`Storage`], such as a `TempDir`, that needs to live as long
+/// the storage itself.
+pub(crate) struct GuardedStorage<S: Storage, G: Send> {
+    storage: S,
+    _guard: G,
+}
+
+impl<S: Storage, G: Send> GuardedStorage<S, G> {
+    pub(crate) fn new(storage: S, guard: G) -> Self {
+        Self {
+            storage,
+            _guard: guard,
+        }
+    }
+}
+
+#[async_trait]
+impl<S: Storage, G: Send> Storage for GuardedStorage<S, G> {
+    async fn txn<'a>(&'a mut self) -> Result<Box<dyn StorageTxn + Send + 'a>> {
+        self.storage.txn().await
+    }
+}
 
 /// Define a collection of storage tests that apply to all storage implementations.
 macro_rules! storage_tests_base {


### PR DESCRIPTION
With these changes it passes all tests on a recent Haiku nightly. I will add a CI test in a separate PR once the beta6 github action exists.

- WAL mode is broken on Haiku due to a posix bug
- Don't immediately drop the tmp_dir before it is used in the test helper